### PR TITLE
Fix for Heroku - ValueError: Buffer dtype mismatch, expected 'SIZE_t' but got 'int'

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,13 +34,12 @@ def load_data():
     # loaded_data = pd.read_csv("cleaned_data.csv")
     return pd.read_csv("cleaned_data.csv")
 
+data = load_data()
 
 if st.checkbox('data'):
     '''
     ## Data Used for Training
     '''
-
-    data = load_data()
 
     data
     
@@ -73,17 +72,10 @@ if st.checkbox('data'):
     st.markdown('---')
 
 
-#load model
-@st.cache(allow_output_mutation=True) #added 'allow_output_mutation=True' because kept getting 'CachedObjectMutationWarning: Return value of load_model() was mutated between runs.'
-def load_model():
-    return pickle.load(open('model.pkl', 'rb'))
-
-model = load_model()
+model = pickle.load(open('model.pkl', 'rb'))
 
 #show evaluation metrics
 if st.checkbox('model metrics'):
-
-    data = load_data()
 
     #split the same way as used to train (from cleaned_data_pipeline.py)
     features = data.drop('Classification', axis=1)


### PR DESCRIPTION
Launched on heroku and got this error message:

```
ValueError: Buffer dtype mismatch, expected 'SIZE_t' but got 'int'
Traceback:
File "/app/.heroku/python/lib/python3.6/site-packages/streamlit/ScriptRunner.py", line 322, in _run_script
    exec(code, module.__dict__)
File "/app/app.py", line 81, in <module>
    model = load_model()
File "/app/.heroku/python/lib/python3.6/site-packages/streamlit/caching.py", line 591, in wrapped_func
    return get_or_create_cached_value()
File "/app/.heroku/python/lib/python3.6/site-packages/streamlit/caching.py", line 575, in get_or_create_cached_value
    return_value = func(*args, **kwargs)
File "/app/app.py", line 79, in load_model
    return pickle.load(open('model.pkl', 'rb'))
File "sklearn/tree/_tree.pyx", line 607, in sklearn.tree._tree.Tree.__cinit__
```

So I removed the `load_model()` function and just used `model = [model file]`. This runs fine in my local env with `load_model()`

Also, I kept getting a `data` not defined error when I ran it again locally after removing `load_model()`. I'm not actually sure how it worked locally before this. Previously, `data = load_data()` was only created if the data and model metrics boxes were checked but data was being used under the input methods select box as well.

So I just added `data = load_data()` to the top and made it load at the beginning so it'll be available with global scope