### PR TITLE
Revert "Bump numpy from 1.18.5 to 1.22.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit==0.65.2
 pandas==1.0.5
-numpy==1.22.0
+numpy==1.18.5
 scikit-learn==0.23.1
 tpot==0.11.5


### PR DESCRIPTION
Reverts batmanscode/breastcancer-predictor#4

heroku wasn't deploying and looks like it's numpy