### PR TITLE
Remove numpy since unused

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,6 @@ import base64
 import pickle
 import warnings
 
-import numpy as np
 import pandas as pd
 import streamlit as st
 from sklearn.decomposition import FastICA

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 streamlit==0.65.2
 pandas==1.0.5
-numpy==1.18.5
 scikit-learn==0.23.1
 tpot==0.11.5


### PR DESCRIPTION
causing the heroku build to fail and was unused anyway

```
   note: This error originates from a subprocess, and is likely not a problem with pip.
 error: legacy-install-failure
 
 × Encountered error while trying to install package.
 ╰─> numpy
```